### PR TITLE
新增函数和修改小bug

### DIFF
--- a/looter/__init__.py
+++ b/looter/__init__.py
@@ -268,7 +268,20 @@ def links(res: requests.models.Response, search=None, absolute=False) -> list:
     if search:
         hrefs = [href for href in hrefs if search in href]
     if absolute:
-        hrefs = [domain + href for href in hrefs if not href.startswith('http')]
+        hrefs = [domain[:-1] + href for href in hrefs if not href.startswith('http')]
+    return hrefs
+
+def re_links(res: requests.models.Response, pattern: str) -> list:
+    """
+        Args:
+            res (requests.models.Response): The response of the page.
+            pattern (str): Regular expression.
+
+        Returns:
+            list: Regular expressions that match the rules.
+    """
+    hrefs = links(res,absolute=True)
+    hrefs = [href for href in hrefs if re.findall(pattern,href)]
     return hrefs
 
 

--- a/test_looter.py
+++ b/test_looter.py
@@ -36,3 +36,16 @@ def test_links():
     res = lt.send_request(domain)
     r = lt.links(res)
     assert type(r) == list
+
+
+@pytest.mark.ok
+def test_re_links():
+    res = lt.send_request('http://www.spbeen.com')
+    hrefs = lt.re_links(res,'https?://www.spbeen.com//p/.*?')
+    assert type(hrefs) == list
+
+@pytest.mark.ok
+def test_absolute_links():
+    res = lt.send_request('http://www.spbeen.com')
+    hrefs = [href.replace('http://','') for href in lt.links(res, absolute=True)]
+    assert len([href for href in hrefs if "//" in href])==0


### PR DESCRIPTION
修复looter的links()函数，//只能存在于http[s]中，url其余部分不应该出现
looter新增re_links()函数，匹配正则